### PR TITLE
MS-2839: fix post message call for cross domain iframe (window.name i…

### DIFF
--- a/sdk/res/raw/sdkjs.js
+++ b/sdk/res/raw/sdkjs.js
@@ -146,7 +146,12 @@
 
     sdkjs.postMessageToFrames = function (message) {
         for (var i = 0; i < anjamFrames.length; i++) {
-            anjam.anlog("Dispatching message to window name " + anjamFrames[i].name);
+            try {
+                anjam.anlog("Dispatching message to window name " + anjamFrames[i].name);
+            } catch(e) {
+                // In Cross Domain communication, the window's name is not available
+                anjam.anlog("Dispatching message to a cross domain window");
+            }
             anjamFrames[i].postMessage(message, "*");
         }
     }


### PR DESCRIPTION
Fix post message call for cross domain iframe.
window.name is not accessible for cross domain window (security access block).