### PR TITLE
This fixes a memory-leak occurring when an AdWebView is destroyed 

### DIFF
--- a/sdk/src/com/appnexus/opensdk/AdWebView.java
+++ b/sdk/src/com/appnexus/opensdk/AdWebView.java
@@ -1000,12 +1000,20 @@ class AdWebView extends WebView implements Displayable,
 
     @Override
     protected void onDetachedFromWindow() {
+        removeViewTreeObserverListeners();
         super.onDetachedFromWindow();
         if (progressDialog != null && progressDialog.isShowing()) {
             progressDialog.dismiss();
         }
     }
 
+    private void removeViewTreeObserverListeners() {
+        ViewTreeObserver treeObserver = getViewTreeObserver();
+        if (treeObserver.isAlive()) {
+            treeObserver.removeOnScrollChangedListener(this);
+            treeObserver.removeGlobalOnLayoutListener(this);
+        }
+    }
 
     @Override
     protected void onAttachedToWindow() {


### PR DESCRIPTION
This fixes a memory-leak occurring when an AdWebView is destroyed and removed from the view tree. The view tree will continue to hold a reference to the AdWebView, preventing it from being GCd.