### PR TITLE
Made prevent-web-view-scrolling configurable

### DIFF
--- a/sdk/src/com/appnexus/opensdk/AdWebView.java
+++ b/sdk/src/com/appnexus/opensdk/AdWebView.java
@@ -860,7 +860,11 @@ class AdWebView extends WebView implements Displayable,
 
     @Override
     public void scrollTo(int x, int y) {
-        super.scrollTo(0, 0);
+        if (Settings.getSettings().preventWebViewScrolling) {
+            super.scrollTo(0, 0);
+        } else {
+            super.scrollTo(x, y);
+        }
     }
 
     public void fireMRAIDEnabled() {

--- a/sdk/src/com/appnexus/opensdk/SDKSettings.java
+++ b/sdk/src/com/appnexus/opensdk/SDKSettings.java
@@ -295,6 +295,26 @@ public class SDKSettings {
     }
 
     /**
+     * Enables or disables the scroll protection of the web view of the advertisement.
+     *
+     * It is enabled by default.
+     *
+     * @param preventWebViewScrolling
+     * true - Default value, the web view will stay at the top of the page (0, 0) when the scroll position is set.
+     * false - The web view will use the default behaviour and allow scrolling.
+     */
+    public static void setPreventWebViewScrolling(boolean preventWebViewScrolling) {
+        Settings.getSettings().preventWebViewScrolling = preventWebViewScrolling;
+    }
+
+    /**
+     * @return boolean which states if the scrolling of the advertisement web view is prevented or not.
+     */
+    public static boolean getPreventWebViewScrolling() {
+        return Settings.getSettings().preventWebViewScrolling;
+    }
+
+    /**
      * @return boolean which states if the BackgroundThreading is enabled or not
      * */
     public static boolean isBackgroundThreadingEnabled() {

--- a/sdk/src/com/appnexus/opensdk/utils/Settings.java
+++ b/sdk/src/com/appnexus/opensdk/utils/Settings.java
@@ -58,6 +58,8 @@ public class Settings {
     public Location location = null;
     public int locationDecimalDigits = -1;
 
+    public boolean preventWebViewScrolling = true;
+
     public HashMap<String, String> externalMediationClasses = new HashMap<String, String>();
     private HashSet<String> invalidBannerNetworks = new HashSet<String>();
     private HashSet<String> invalidInterstitialNetworks = new HashSet<String>();


### PR DESCRIPTION
Hi

I'm a mobile developer from DPG Media and we are experimenting to create some rich media ads that can scroll the web view to show additional content. We got it working with our GAM ads, but since we are migrating to Xandr, we would like to use those ads in combination with your SDK as well.

The `AdWebView` class overwrites the `scrollTo` method, which blocks us from scrolling the ad. We removed this and created a local build and then it was working fine. We assume this functionality is there to prevent accidental scrolling for regular ads, that's why we decided to make it configurable and used a default value to keep the existing behavior.

Is the `Settings` class the correct place to ad such configuration?

Thank you for reviewing.