### PR TITLE
Null check adListener in onLazyAdLoaded()

### DIFF
--- a/sdk/src/com/appnexus/opensdk/AdView.java
+++ b/sdk/src/com/appnexus/opensdk/AdView.java
@@ -1284,7 +1284,9 @@ public abstract class AdView extends FrameLayout implements Ad, MultiAd {
         public void onLazyAdLoaded(ANAdResponseInfo adResponseInfo) {
             isFetching = false;
             setAdResponseInfo(adResponseInfo);
-            adListener.onLazyAdLoaded(AdView.this);
+            if (adListener != null) {
+                adListener.onLazyAdLoaded(AdView.this);
+            }
         }
     }
 


### PR DESCRIPTION
Fix for https://github.com/appnexus/mobile-sdk-android/issues/54