### PR TITLE
Reduced visibility log level and used proper tag

### DIFF
--- a/sdk/src/com/appnexus/opensdk/VisibilityDetector.java
+++ b/sdk/src/com/appnexus/opensdk/VisibilityDetector.java
@@ -108,7 +108,7 @@ class VisibilityDetector {
                     VisibilityListener listener = getListener(viewWeakReference);
                     View view = viewWeakReference.get();
                     if (listener != null) {
-                        Clog.e("Visibility", view.toString() + ", isVisible: " + isVisible(view));
+                        Clog.d(Clog.visibilityLogTag, view.toString() + ", isVisible: " + isVisible(view));
                         listener.onVisibilityChanged(isVisible(view));
                     } else {
                         destroy(view);


### PR DESCRIPTION
Currently the VisibilityDetector is logging the visibility state of ads quite aggressively.

I have reduced that level to debug and used the tag that already existed in `Clog`.